### PR TITLE
Fix s-format argument

### DIFF
--- a/org-incoming.el
+++ b/org-incoming.el
@@ -543,7 +543,7 @@ Sets title and date from CUR-NAME and CUR-DATE."
                     ("link" . ,org-incoming--cur-pdf-target)
                     ("extracted" . ,org-incoming--cur-extracted)))
          (content (s-format (org-incoming--get-setting "annotation-template")
-                            #'aget context)))
+                            'aget context)))
     
     (with-temp-buffer
       (insert content)


### PR DESCRIPTION
We should pass symbol, not function, if we use standard helper functions of `s-format`. This fixes the following byte-compile warning.

```
org-incoming.el:546:31: Warning: the function ‘aget’ is not known to be
    defined.
```